### PR TITLE
Fix wrong type hint for make_grid parameter

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -19,7 +19,7 @@ def make_grid(
     normalize: bool = False,
     value_range: Optional[Tuple[int, int]] = None,
     scale_each: bool = False,
-    pad_value: int = 0,
+    pad_value: float = 0,
     **kwargs,
 ) -> torch.Tensor:
     """


### PR DESCRIPTION
As the documentation for the `pad_value` parameter states, it's supposed to be a float, not an int.

It looks like this was just a small typo in #2034.